### PR TITLE
Include column `pics_95perc_credset` to V2D.

### DIFF
--- a/src/main/scala/ot/geckopipe/index/V2DIndex.scala
+++ b/src/main/scala/ot/geckopipe/index/V2DIndex.scala
@@ -64,7 +64,6 @@ object V2DIndex extends LazyLogging {
         "ld_available",
         "pics_mu",
         "pics_postprob",
-        "pics_95perc_credset",
         "pics_99perc_credset"
       )
       .cache()


### PR DESCRIPTION
Resolves opentargets/platform#2695