### PR TITLE
2209 release update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,18 +13,9 @@ open-targets-genetics-63ea40a7fb68.json
 
 /*.csv
 /*.conf
-#### java ####
-# Compiled class file
-*.class
+.bsp
+.bloop
 
-# Log file
-*.log
-
-# BlueJ files
-*.ctxt
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
 
 # Package Files #
 *.jar
@@ -33,10 +24,6 @@ open-targets-genetics-63ea40a7fb68.json
 *.zip
 *.tar.gz
 *.rar
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-
 
 #### sbt ####
 # Simple Build Tool

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,18 @@
 import Dependencies._
 
+import scala.sys.process.Process
+
 val buildResolvers = Seq(
   "Maven repository" at "https://download.java.net/maven/2/",
   "Typesafe Repo" at "https://repo.typesafe.com/typesafe/releases/",
   "Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
   "Sonatype Releases" at "https://oss.sonatype.org/content/repositories/releases"
 )
+
+lazy val jarName = {
+  val commit = Process(s"git log --oneline").lineStream.head.take(7)
+  s"etl-genetics-$commit.jar"
+}
 
 lazy val root = (project in file("."))
   .settings(
@@ -27,5 +34,6 @@ lazy val root = (project in file("."))
         MergeStrategy.concat
       case PathList("META-INF", _ @_*) => MergeStrategy.discard
       case _                           => MergeStrategy.first
-    }
+    },
+    assembly / assemblyJarName := jarName
   )

--- a/configuration/2205_0.conf
+++ b/configuration/2205_0.conf
@@ -1,0 +1,22 @@
+output = "gs://genetics-portal-dev-data/22.05.0/outputs"
+input = "gs://genetics-portal-dev-data/22.05.0/inputs"
+
+variant-index.raw = "gs://genetics-portal-dev-data/21.10/inputs/variant-annotation/190129/variant-annotation.parquet"
+ensembl.lut = ${input}"/lut/homo_sapiens_core_106_38_genes.json.gz"
+vep.homo-sapiens-cons-scores = "gs://genetics-portal-dev-data/22.03/inputs/lut/vep_consequences.tsv"
+interval.path = "gs://genetics-portal-dev-staging/v2g/interval/*/*/*/data.parquet/"
+qtl.path = "gs://genetics-portal-dev-staging/v2g/qtl/220331/"
+
+# Requires input
+v2d-input = "gs://genetics-portal-dev-staging/v2d/220401/"
+variant-disease {
+  studies = ${v2d-input}"studies.parquet"
+  toploci = ${v2d-input}"toploci.parquet"
+  finemapping = ${v2d-input}"finemapping.parquet"
+  ld = ${v2d-input}"ld.parquet"
+  overlapping = ${v2d-input}"locus_overlap.parquet"
+  coloc = "gs://genetics-portal-dev-staging/coloc/220408/coloc_processed_w_betas_fixed.parquet"
+  efos = ${v2d-input}"trait_efo.parquet"
+}
+
+manhattan.locus-gene = "gs://genetics-portal-dev-staging/l2g/220613/predictions/l2g.full.220613.parquet/"

--- a/configuration/2205_2.conf
+++ b/configuration/2205_2.conf
@@ -1,9 +1,8 @@
 output = "gs://genetics-portal-dev-data/22.05.2/outputs"
-input = "gs://genetics-portal-dev-data/22.05.0/inputs"
-format = "json"
+format = "parquet"
 
 variant-index.raw = "gs://genetics-portal-dev-data/21.10/inputs/variant-annotation/190129/variant-annotation.parquet"
-ensembl.lut = ${input}"/lut/homo_sapiens_core_106_38_genes.json.gz"
+ensembl.lut = "gs://genetics-portal-dev-data/22.05.0/inputs/lut/homo_sapiens_core_106_38_genes.json.gz"
 vep.homo-sapiens-cons-scores = "gs://genetics-portal-dev-data/22.03/inputs/lut/vep_consequences.tsv"
 interval.path = "gs://genetics-portal-dev-staging/v2g/interval/*/*/*/data.parquet/"
 qtl.path = "gs://genetics-portal-dev-staging/v2g/qtl/220331/"
@@ -20,4 +19,4 @@ variant-disease {
   efos = ${v2d-input}"trait_efo.parquet"
 }
 
-manhattan.locus-gene = "gs://genetics-portal-dev-staging/l2g/220613/predictions/l2g.full.220613.parquet/"
+manhattan.locus-gene = "gs://genetics-portal-dev-staging/l2g/220712/predictions/l2g.full.220712.parquet/"

--- a/configuration/2205_2.conf
+++ b/configuration/2205_2.conf
@@ -1,0 +1,23 @@
+output = "gs://genetics-portal-dev-data/22.05.2/outputs"
+input = "gs://genetics-portal-dev-data/22.05.0/inputs"
+format = "json"
+
+variant-index.raw = "gs://genetics-portal-dev-data/21.10/inputs/variant-annotation/190129/variant-annotation.parquet"
+ensembl.lut = ${input}"/lut/homo_sapiens_core_106_38_genes.json.gz"
+vep.homo-sapiens-cons-scores = "gs://genetics-portal-dev-data/22.03/inputs/lut/vep_consequences.tsv"
+interval.path = "gs://genetics-portal-dev-staging/v2g/interval/*/*/*/data.parquet/"
+qtl.path = "gs://genetics-portal-dev-staging/v2g/qtl/220331/"
+
+# Requires input
+v2d-input = "gs://genetics-portal-dev-staging/v2d/220401/"
+variant-disease {
+  studies = ${v2d-input}"studies.parquet"
+  toploci = ${v2d-input}"toploci.parquet"
+  finemapping = ${v2d-input}"finemapping.parquet"
+  ld = ${v2d-input}"ld.parquet"
+  overlapping = ${v2d-input}"locus_overlap.parquet"
+  coloc = "gs://genetics-portal-dev-staging/coloc/220408/coloc_processed_w_betas.parquet"
+  efos = ${v2d-input}"trait_efo.parquet"
+}
+
+manhattan.locus-gene = "gs://genetics-portal-dev-staging/l2g/220613/predictions/l2g.full.220613.parquet/"

--- a/configuration/2208_0.conf
+++ b/configuration/2208_0.conf
@@ -1,0 +1,22 @@
+output = "gs://genetics-portal-dev-data/22.08.0/outputs"
+format = "parquet"
+
+variant-index.raw = "gs://genetics-portal-dev-data/21.10/inputs/variant-annotation/190129/variant-annotation.parquet"
+ensembl.lut = "gs://genetics-portal-dev-data/22.08.0/inputs/lut/homo_sapiens_core_107_38_genes.json.gz"
+vep.homo-sapiens-cons-scores = "gs://genetics-portal-dev-data/22.03/inputs/lut/vep_consequences.tsv"
+interval.path = "gs://genetics-portal-dev-staging/v2g/interval/*/*/*/data.parquet/"
+qtl.path = "gs://genetics-portal-dev-staging/v2g/qtl/220331/"
+
+# Requires input
+v2d-input = "gs://genetics-portal-dev-staging/v2d/220401/"
+variant-disease {
+  studies = ${v2d-input}"studies.parquet"
+  toploci = ${v2d-input}"toploci.parquet"
+  finemapping = ${v2d-input}"finemapping.parquet"
+  ld = ${v2d-input}"ld.parquet"
+  overlapping = ${v2d-input}"locus_overlap.parquet"
+  coloc = "gs://genetics-portal-dev-staging/coloc/220408/coloc_processed_w_betas.parquet"
+  efos = ${v2d-input}"trait_efo.parquet"
+}
+
+manhattan.locus-gene = "gs://genetics-portal-dev-staging/l2g/220712/predictions/l2g.full.220712.parquet/"

--- a/documentation/ot_genetics_deployment.md
+++ b/documentation/ot_genetics_deployment.md
@@ -116,7 +116,7 @@ utilities to run a release.
 - [ ] update variables in bash script in `/scripts/prepare_inputs.sh` (input script)
 - [ ] run input script in VM to move files from staging to dev buckets
     - Most of the inputs are used for the pipeline, but there are two static datasets which are copied, sumstats (sa)
-      and `v2g_credset`.
+      and `v2d_credset`.
     - It's to pipe the STDOUT of the script to a file which can be provided to the genetics/data team for 
       confirmation the correct files were used. `./scripts/prepare_inputs.sh >> genetics_input_log.txt`
 - [ ] create a configuration file for release in `config`:
@@ -136,7 +136,7 @@ utilities to run a release.
       `documentation/step_dependencies` for the correct order. 
        - In general run in the following phases (some steps can be run concurrently): 
           - variant-index (30m), variant-gene (180min)
-          - dictionaries, variant-disease (2min), distance-nearest (140min), variant-disease-coloc (2min)
+          - dictionaries, variant-disease (2min), variant-disease-coloc (2min)
           - disease-variant-gene (25min)
           - scored datasets (130min)
           - manhattan (25min) (Run this _after_ the following steps)
@@ -157,8 +157,7 @@ utilities to run a release.
   `infrastructure/gcp/genetics/create-elasticsearch-node.sh`
 - [ ] export variables for the two created VMs:(bind the internal GCP IP address, this assumes you're in a GCP VM yourself.)
   - `export ES_HOST=$(gcloud compute instances list | grep -i run | grep elasticsearch | awk '{ print $4 }' | tail -1)`
-  - `export CLICKHOUSE_HOST=$(gcloud compute instances list | grep -i run | grep clickhouse | awk '{ print $4 }' | tail 
-    -1)`
+  - `export CLICKHOUSE_HOST=$(gcloud compute instances list | grep -i run | grep clickhouse | awk '{ print $4 }' | tail -1)`
 - [ ] activate the correct python environment: `conda activate backend-genetics`
 - [ ] run the script `loaders/clickhouse/create_and_load_everything_from_scratch.sh` in the `genetics-backend` 
   repository, providing a link to the input files. 

--- a/documentation/step_dependencies.puml
+++ b/documentation/step_dependencies.puml
@@ -13,7 +13,6 @@ artifact vi as "variant-index" <<noDependencies>>
 artifact dictionaries <<dependencies>>
 artifact vd as "variant-disease" <<dependencies>>
 artifact vdc as "variant-disease-coloc" <<dependencies>>
-artifact dn as "distance-nearest" <<dependencies>>
 artifact dvg as "disease-variant-gene" <<dependencies>>
 artifact sd as "scored-datasets" <<dependencies>>
 artifact manhattan <<dependencies>>
@@ -23,7 +22,6 @@ vi --> dictionaries
 vi --> vd
 vi --> vg
 vi --> vdc
-vi --> dn
 vd --> dvg
 vg --> dvg
 dvg --> sd

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
     "org.scalacheck" %% "scalacheck" % "1.14.3"
   )
 
-  lazy val sparkVersion = "3.1.2"
+  lazy val sparkVersion = "3.1.3"
   lazy val sparkDeps = Seq(
     "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
     "org.apache.spark" %% "spark-sql" % sparkVersion % "provided"

--- a/src/main/scala/ot/geckopipe/Main.scala
+++ b/src/main/scala/ot/geckopipe/Main.scala
@@ -18,14 +18,6 @@ class Commands(val c: Configuration)(implicit val ss: SparkSession) extends Lazy
     vidx.table.write.parquet(c.variantIndex.path)
   }
 
-  def distanceNearest(): Unit = {
-    logger.info("exec distance-nearest command")
-    val vIdx = VariantIndex.builder(c).load
-
-    val nearestDF = Distance(vIdx, c)
-    nearestDF.table.write.json(c.nearest.path)
-  }
-
   def variantDiseaseColoc(): Unit = {
     logger.info("exec distance-nearest command")
     val variantColumns = VariantIndex.columns.map(col)

--- a/src/main/scala/ot/geckopipe/Main.scala
+++ b/src/main/scala/ot/geckopipe/Main.scala
@@ -116,6 +116,7 @@ class Commands(val c: Configuration)(implicit val ss: SparkSession) extends Lazy
 
     d2v2gScored.write
       .format(c.format)
+      .option("maxRecordsPerFile", 1000000)
       .save(c.scoredDatasets.diseaseVariantGeneScored)
 
   }

--- a/src/main/scala/ot/geckopipe/index/V2DIndex.scala
+++ b/src/main/scala/ot/geckopipe/index/V2DIndex.scala
@@ -33,7 +33,7 @@ object V2DIndex extends LazyLogging {
         StructField("lead_ref", StringType) ::
         StructField("lead_alt", StringType) ::
         StructField("tag_chrom", StringType) ::
-        StructField("tag_pos", LongType) ::
+        StructField("tag_pos", IntegerType) ::
         StructField("tag_ref", StringType) ::
         StructField("tag_alt", StringType) ::
         StructField("overall_r2", DoubleType) ::

--- a/src/main/scala/ot/geckopipe/index/V2DIndex.scala
+++ b/src/main/scala/ot/geckopipe/index/V2DIndex.scala
@@ -26,7 +26,7 @@ object V2DIndex extends LazyLogging {
         StructField("n_initial", LongType) ::
         StructField("n_replication", LongType) ::
         StructField("n_cases", LongType) ::
-        StructField("trait_category", DoubleType) ::
+        StructField("trait_category", StringType) ::
         StructField("num_assoc_loci", LongType) ::
         StructField("lead_chrom", StringType) ::
         StructField("lead_pos", LongType) ::
@@ -152,7 +152,7 @@ object V2DIndex extends LazyLogging {
       .withColumn("trait_efos", coalesce(col("trait_efos"), typedLit(Array.empty[String])))
       .withColumn(
         "trait_category",
-        coalesce(when(length($"trait_category") > 0, $"trait_category"), lit("Uncategorised"))
+        coalesce(col("trait_category"), lit("Uncategorised"))
       )
       .filter($"trait_reported".isNotNull)
       .orderBy(col("study_id").asc)


### PR DESCRIPTION
- Remove unused distance step
- Add jar names based on commit hashes automatically
- Update documentation
- Fix type errors in V2D: these were previously hidden because JSON could be wrangled into the correct shape automatically but failed with Parquet strict type checking
- Adding historical configuration files
- Updating workflow into two phases. The first creates everything needed to run L2G: the second is just the Manhattan step and is run after we have the L2G outputs
- Limit the number of records per file for d2v2g.